### PR TITLE
(fix): add post status draft to query

### DIFF
--- a/src/Components/PatternContent.php
+++ b/src/Components/PatternContent.php
@@ -21,6 +21,7 @@ class PatternContent extends Component
 	{
 		$pattern = new \WP_Query([
 			'post_type' => 'wp_block',
+			'post_status' => ['publish', 'draft'],
 			'name' => $this->slug,
 		]);
 


### PR DESCRIPTION
De footer werd niet zichtbaar als je niet ingelogd bent. Dit komt omdat post_status standaard op publish staat en als je ingelogd bent dan komen er daar een aantal bij, zie: https://developer.wordpress.org/reference/classes/wp_query/#status-parameters. Omdat in de code geregeld is dat patronen altijd als draft opgeslagen worden denk ik dat dit wel de oplossing is.