### PR TITLE
(feat): add accordion components

### DIFF
--- a/resources/views/components/accordion/index.blade.php
+++ b/resources/views/components/accordion/index.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'accordion-wrapper']) }}>
+	{{ $slot }}
+</div>

--- a/resources/views/components/accordion/item/index.blade.php
+++ b/resources/views/components/accordion/item/index.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'ac']) }}>
+	{{ $slot }}
+</div>

--- a/resources/views/components/accordion/item/panel.blade.php
+++ b/resources/views/components/accordion/item/panel.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'ac-panel']) }}>
+	{{ $slot }}
+</div>

--- a/resources/views/components/accordion/item/trigger.blade.php
+++ b/resources/views/components/accordion/item/trigger.blade.php
@@ -1,0 +1,3 @@
+<button {{ $attributes->merge(['class' => 'ac-trigger']) }}>
+	{{ $slot }}
+</button>

--- a/src/Components/Accordion.php
+++ b/src/Components/Accordion.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yard\Brave\Components;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class Accordion extends Component
+{
+	public function render(): Factory|View
+	{
+		return view('brave::components.accordion.index');
+	}
+}

--- a/src/ComponentsServiceProvider.php
+++ b/src/ComponentsServiceProvider.php
@@ -6,6 +6,7 @@ namespace Yard\Brave;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Yard\Brave\Components\Accordion;
 use Yard\Brave\Components\BackButton;
 use Yard\Brave\Components\FeedbackForm;
 use Yard\Brave\Components\ImgFocalPoint;
@@ -21,7 +22,7 @@ class ComponentsServiceProvider extends PackageServiceProvider
 			->name('components')
 			->hasConfigFile()
 			->hasViews('brave')
-			->hasViewComponents('brave', PatternContent::class, SocialIcon::class, BackButton::class, ImgFocalPoint::class, FeedbackForm::class);
+			->hasViewComponents('brave', Accordion::class, BackButton::class, FeedbackForm::class,  ImgFocalPoint::class, PatternContent::class, SocialIcon::class);
 	}
 
 	public function packageBooted(): void


### PR DESCRIPTION
De accordion is opgedeeld in components zodat we op een centrale plek de werking kunnen gaan regelen. Het uiteindelijke idee is ook dat we de accordion javascript hierin gaan zetten zodat de javascript alleen wordt ingeladen op de plekken als het component gebruikt wordt.

PR hoe het in brave gebruikt wordt: https://github.com/yardinternet/brave/pull/182