### PR TITLE
fix: don't display inactive forms

### DIFF
--- a/src/Components/FeedbackForm.php
+++ b/src/Components/FeedbackForm.php
@@ -34,10 +34,10 @@ class FeedbackForm extends Component
 		}
 
 		return GFForms::get_form(
-			$this->id,
-			$this->displayTitle,
-			$this->displayDescription,
-			$this->ajax,
+			form_id: $this->id,
+			display_title: $this->displayTitle,
+			display_description: $this->displayDescription,
+			ajax: $this->ajax,
 		);
 	}
 


### PR DESCRIPTION
The fourth parameter of get_form is not ajax but force_display, resulting in inactive forms being displayed.