### PR TITLE
feat: add readspeaker component

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Usage:
 
 Configure the admin behavior of each pattern in the `components.php` config file to automatically save them as drafts (thus hiding them from the pattern inserter), prevent their deletion, and add custom labels in the admin view.
 
+### Read Speaker
+
+Adds a ReadSpeaker button on specific places with the component and automatically adds it to the content of H1 blocks in the post content. Make sure to configure the `readSpeaker` settings in the `components.php` config file to set your customer ID and other options.
+
+Usage:
+
+```blade
+<x-brave-read-speaker />
+```
+
 ## About us
 
 [![banner](https://raw.githubusercontent.com/yardinternet/.github/refs/heads/main/profile/assets/small-banner-github.svg)](https://www.yard.nl/werken-bij/)

--- a/config/components.php
+++ b/config/components.php
@@ -31,4 +31,10 @@ return [
 			'not_found' => '404 error',
 		],
 	],
+	'readSpeaker' => [
+		'customerId' => null,
+		'readId' => 'main',
+		'disable' => '',
+		'automaticallyAddToH1' => true,
+	],
 ];

--- a/resources/views/components/read-speaker.blade.php
+++ b/resources/views/components/read-speaker.blade.php
@@ -1,0 +1,7 @@
+<div id="{{ wp_unique_prefixed_id('readspeaker_button_') }}" class="rs_skip rsbtn rs_preserve">
+    <a rel="nofollow" class="rsbtn_play" title="Laat de tekst voorlezen met ReadSpeaker webReader"
+        href="https://app-eu.readspeaker.com/cgi-bin/rsent?customerid={{ $customerId }}&amp;lang=nl_nl&amp;readid={{ $readId }}&amp;url={{ rawurlencode(get_permalink()) }}">
+        <span class="rsbtn_left rsimg rspart"><span class="rsbtn_text"><span>Lees voor</span></span></span>
+        <span class="rsbtn_right rsimg rsplay rspart"></span>
+    </a>
+</div>

--- a/resources/views/components/read-speaker.blade.php
+++ b/resources/views/components/read-speaker.blade.php
@@ -1,6 +1,6 @@
-<div id="{{ wp_unique_prefixed_id('readspeaker_button_') }}" class="rs_skip rsbtn rs_preserve">
+<div id="{{ wp_unique_prefixed_id('readspeaker_button_') }}" class="brave-read-speaker rs_skip rsbtn rs_preserve">
     <a rel="nofollow" class="rsbtn_play" title="Laat de tekst voorlezen met ReadSpeaker webReader"
-        href="https://app-eu.readspeaker.com/cgi-bin/rsent?customerid={{ $customerId }}&amp;lang=nl_nl&amp;readid={{ $readId }}&amp;url={{ rawurlencode(get_permalink()) }}">
+        href="{{ $src }}">
         <span class="rsbtn_left rsimg rspart"><span class="rsbtn_text"><span>Lees voor</span></span></span>
         <span class="rsbtn_right rsimg rsplay rspart"></span>
     </a>

--- a/src/Components/ReadSpeaker.php
+++ b/src/Components/ReadSpeaker.php
@@ -34,7 +34,7 @@ class ReadSpeaker extends Component
 
 	public function render(): View|Factory|string
 	{
-		if('' === $this->src) {
+		if ('' === $this->src) {
 			return '';
 		}
 

--- a/src/Components/ReadSpeaker.php
+++ b/src/Components/ReadSpeaker.php
@@ -12,18 +12,29 @@ class ReadSpeaker extends Component
 {
 	public int $customerId;
 	public string $readId;
-	public string $disable;
+	public string $src = '';
 
 	public function __construct()
 	{
 		$this->customerId = (int) config('components.readSpeaker.customerId', 0);
 		$this->readId = config('components.readSpeaker.readId', 'main');
-		$this->disable = config('components.readSpeaker.disable', '');
+
+		if (0 !== $this->customerId) {
+			$this->src = add_query_arg(
+				[
+					'customerid' => $this->customerId,
+					'lang' => 'nl_nl',
+					'readid' => $this->readId,
+					'url' => rawurlencode(get_permalink()),
+				],
+				'https://app-eu.readspeaker.com/cgi-bin/rsent',
+			);
+		}
 	}
 
 	public function render(): View|Factory|string
 	{
-		if (0 === $this->customerId) {
+		if('' === $this->src) {
 			return '';
 		}
 

--- a/src/Components/ReadSpeaker.php
+++ b/src/Components/ReadSpeaker.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yard\Brave\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\Factory;
+use Illuminate\View\View;
+
+class ReadSpeaker extends Component
+{
+	public int $customerId;
+	public string $readId;
+	public string $disable;
+
+	public function __construct()
+	{
+		$this->customerId = (int) config('components.readSpeaker.customerId', 0);
+		$this->readId = config('components.readSpeaker.readId', 'main');
+		$this->disable = config('components.readSpeaker.disable', '');
+	}
+
+	public function render(): View|Factory|string
+	{
+		if (0 === $this->customerId) {
+			return '';
+		}
+
+		return view('brave::components.read-speaker');
+	}
+}

--- a/src/ComponentsServiceProvider.php
+++ b/src/ComponentsServiceProvider.php
@@ -13,6 +13,7 @@ use Yard\Brave\Components\Dialog;
 use Yard\Brave\Components\FeedbackForm;
 use Yard\Brave\Components\ImgFocalPoint;
 use Yard\Brave\Components\PatternContent;
+use Yard\Brave\Components\ReadSpeaker;
 use Yard\Brave\Components\SocialIcon;
 use Yard\Hook\Registrar;
 
@@ -24,7 +25,7 @@ class ComponentsServiceProvider extends PackageServiceProvider
 			->name('components')
 			->hasConfigFile()
 			->hasViews('brave')
-			->hasViewComponents('brave', Accordion::class, BackButton::class, Breadcrumb::class, Dialog::class, FeedbackForm::class,  ImgFocalPoint::class, PatternContent::class, SocialIcon::class);
+			->hasViewComponents('brave', Accordion::class, BackButton::class, Breadcrumb::class, Dialog::class, FeedbackForm::class,  ImgFocalPoint::class, PatternContent::class, ReadSpeaker::class, SocialIcon::class);
 	}
 
 	public function packageBooted(): void
@@ -33,6 +34,10 @@ class ComponentsServiceProvider extends PackageServiceProvider
 
 		if (config('components.hooks.pattern_content.enabled', true)) {
 			$hooks[] = Hooks\PatternContent::class;
+		}
+
+		if (0 !== (int) config('components.readSpeaker.customerId', 0)) {
+			$hooks[] = Hooks\ReadSpeaker::class;
 		}
 
 		(new Registrar($hooks))->registerHooks();

--- a/src/Hooks/ReadSpeaker.php
+++ b/src/Hooks/ReadSpeaker.php
@@ -6,18 +6,18 @@ namespace Yard\Brave\Hooks;
 
 use Yard\Hook\Action;
 use Yard\Hook\Filter;
+use Yard\Brave\Components\ReadSpeaker as ReadSpeakerComponent;
+use Illuminate\Support\Facades\Blade;
 
 class ReadSpeaker
 {
 	private int $customerId;
-	private string $readId;
 	private string $disable;
 	private bool $automaticallyAddToH1;
 
 	public function __construct()
 	{
 		$this->customerId = (int) config('components.readSpeaker.customerId', 0);
-		$this->readId = config('components.readSpeaker.readId', 'main');
 		$this->disable = config('components.readSpeaker.disable', '');
 		$this->automaticallyAddToH1 = (bool) config('components.readSpeaker.automaticallyAddToH1', true);
 	}
@@ -56,10 +56,7 @@ class ReadSpeaker
 		}
 
 		if (isset($block['attrs']['level']) && (int) $block['attrs']['level'] === 1) {
-			return $blockContent . view('brave::components.read-speaker', [
-				'customerId' => $this->customerId,
-				'readId' => $this->readId,
-			])->render();
+			return $blockContent . Blade::renderComponent(new ReadSpeakerComponent());
 		}
 
 		return $blockContent;

--- a/src/Hooks/ReadSpeaker.php
+++ b/src/Hooks/ReadSpeaker.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yard\Brave\Hooks;
+
+use Yard\Hook\Action;
+use Yard\Hook\Filter;
+
+class ReadSpeaker
+{
+	private int $customerId;
+	private string $readId;
+	private string $disable;
+	private bool $automaticallyAddToH1;
+
+	public function __construct()
+	{
+		$this->customerId = (int) config('components.readSpeaker.customerId', 0);
+		$this->readId = config('components.readSpeaker.readId', 'main');
+		$this->disable = config('components.readSpeaker.disable', '');
+		$this->automaticallyAddToH1 = (bool) config('components.readSpeaker.automaticallyAddToH1', true);
+	}
+
+	/**
+	 * Add the ReadSpeaker script to the footer of the site if a valid customer ID is set.
+	 */
+	#[Action('wp_footer')]
+	public function addReadSpeakerScript(): void
+	{
+		$baseUrl = 'https://cdn-eu.readspeaker.com/script/' . $this->customerId . '/webReader/webReader.js';
+
+		$src = add_query_arg(
+			[
+				'pids' => 'wr',
+				'disable' => $this->disable,
+			],
+			$baseUrl
+		);
+
+		wp_print_inline_script_tag('', [
+			'id' => 'readspeaker-script',
+			'src' => $src,
+		]);
+	}
+
+	/**
+	 * Add the ReadSpeaker button partial to H1's
+	 */
+	#[Filter('render_block_core/heading')]
+	#[Filter('render_block_core/post-title')]
+	public function addReadSpeakerButtonToH1(string $blockContent, array $block): string
+	{
+		if (! $this->automaticallyAddToH1) {
+			return $blockContent;
+		}
+
+		if (isset($block['attrs']['level']) && (int) $block['attrs']['level'] === 1) {
+			return $blockContent . view('brave::components.read-speaker', [
+				'customerId' => $this->customerId,
+				'readId' => $this->readId,
+			])->render();
+		}
+
+		return $blockContent;
+	}
+}

--- a/src/Hooks/ReadSpeaker.php
+++ b/src/Hooks/ReadSpeaker.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Yard\Brave\Hooks;
 
+use Illuminate\Support\Facades\Blade;
+use Yard\Brave\Components\ReadSpeaker as ReadSpeakerComponent;
 use Yard\Hook\Action;
 use Yard\Hook\Filter;
-use Yard\Brave\Components\ReadSpeaker as ReadSpeakerComponent;
-use Illuminate\Support\Facades\Blade;
 
 class ReadSpeaker
 {


### PR DESCRIPTION
Steeds meer klanten willen de readspeaker knop onder de h1 hebben. Met dit component kan je heel makkelijk `<x-brave-read-speaker />` toevoegen in alle templates waar het nodig is. En met de hook `addReadSpeakerButtonToH1` wordt het automatisch onder elke h1 in the post content toegevoegd.