### PR TITLE
fix: get_permalink not working for all pages for readspeaker component

### DIFF
--- a/src/Components/ReadSpeaker.php
+++ b/src/Components/ReadSpeaker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yard\Brave\Components;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\View\Component;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
@@ -25,7 +26,7 @@ class ReadSpeaker extends Component
 					'customerid' => $this->customerId,
 					'lang' => 'nl_nl',
 					'readid' => $this->readId,
-					'url' => rawurlencode(get_permalink()),
+					'url' => URL::current(),
 				],
 				'https://app-eu.readspeaker.com/cgi-bin/rsent',
 			);


### PR DESCRIPTION
Er zat toch nog een bug in https://github.com/yardinternet/brave-components/pull/32, get_permalink werkt niet als je bijvoorbeeld op de 404 pagina terecht komt. Ik moet eerlijk bekennen dat ik deze oplossing door AI heb laten schrijven.