### PR TITLE
feat: add tooltip component

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,35 +132,35 @@ Example usage with Navi:
 @php($menu = \Log1x\Navi\Navi::make()->build('primary_navigation'))
 
 @if ($menu->isNotEmpty())
-	<x-brave::nav aria-label="{{ __('Primaire navigatie', 'sage') }}">
-		<x-brave::nav.list>
-			@foreach ($menu->all() as $item)
-				<x-brave::nav.item class="group">
-					<x-brave::nav.link :item="$item" class="text-blue-500" activeClass="text-red-500">
-						{!! $item->label !!}
-						@if ($item->children)
-							<i class="fa-light fa-chevron-down"></i>
-						@endif
-					</x-brave::nav.link>
+    <x-brave::nav aria-label="{{ __('Primaire navigatie', 'sage') }}">
+        <x-brave::nav.list>
+            @foreach ($menu->all() as $item)
+                <x-brave::nav.item class="group">
+                    <x-brave::nav.link :item="$item" class="text-blue-500" activeClass="text-red-500">
+                        {!! $item->label !!}
+                        @if ($item->children)
+                            <i class="fa-light fa-chevron-down"></i>
+                        @endif
+                    </x-brave::nav.link>
 
-					@if ($item->children)
-						<x-brave::nav.dropdown mode="hover" @class([
-							'invisible absolute bg-white',
-							'group-has-aria-expanded:visible',
-						])>
-							@foreach ($item->children as $child)
-								<x-brave::nav.item>
-									<x-brave::nav.link :item="$child" class="text-blue-500" activeClass="text-red-500">
-										{!! $child->label !!}
-									</x-brave::nav.link>
-								</x-brave::nav.item>
-							@endforeach
-						</x-brave::nav.dropdown>
-					@endif
-				</x-brave::nav.item>
-			@endforeach
-		</x-brave::nav.list>
-	</x-brave::nav>
+                    @if ($item->children)
+                        <x-brave::nav.dropdown mode="hover" @class([
+                            'invisible absolute bg-white',
+                            'group-has-aria-expanded:visible',
+                        ])>
+                            @foreach ($item->children as $child)
+                                <x-brave::nav.item>
+                                    <x-brave::nav.link :item="$child" class="text-blue-500" activeClass="text-red-500">
+                                        {!! $child->label !!}
+                                    </x-brave::nav.link>
+                                </x-brave::nav.item>
+                            @endforeach
+                        </x-brave::nav.dropdown>
+                    @endif
+                </x-brave::nav.item>
+            @endforeach
+        </x-brave::nav.list>
+    </x-brave::nav>
 @endif
 
 ```
@@ -201,6 +201,19 @@ Usage without Navi:
         </x-brave::nav.item>
     </x-brave::nav.list>
 </x-brave::nav>
+```
+
+### Tooltip
+
+Usage:
+
+```blade
+<x-brave::tooltip.trigger id="my-tooltip-trigger" ariaDescribedby="my-tooltip">
+    Hover or focus me
+</x-brave::tooltip.trigger>
+<x-brave::tooltip id="my-tooltip">
+    This is the tooltip content.
+</x-brave::tooltip>
 ```
 
 ## About us

--- a/resources/views/components/tooltip/index.blade.php
+++ b/resources/views/components/tooltip/index.blade.php
@@ -1,0 +1,12 @@
+@props(['id', 'arrowClass' => ''])
+
+<div
+    {{ $attributes->merge([
+        'id' => $id,
+        'role' => 'tooltip',
+        'aria-hidden' => 'true',
+        'class' => 'js-brave-tooltip',
+    ]) }}>
+    {{ $slot }}
+    <div @class(['js-brave-tooltip-arrow', $arrowClass])></div>
+</div>

--- a/resources/views/components/tooltip/trigger.blade.php
+++ b/resources/views/components/tooltip/trigger.blade.php
@@ -1,0 +1,11 @@
+@props(['id', 'ariaDescribedby'])
+
+<button
+    {{ $attributes->merge([
+        'id' => $id,
+        'type' => 'button',
+        'class' => 'js-brave-tooltip-trigger',
+        'aria-describedby' => $ariaDescribedby,
+    ]) }}>
+    {{ $slot }}
+</button>

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yard\Brave\Components;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class Tooltip extends Component
+{
+	public function render(): Factory|View
+	{
+		return view('brave::components.tooltip.index');
+	}
+}

--- a/src/ComponentsServiceProvider.php
+++ b/src/ComponentsServiceProvider.php
@@ -16,6 +16,7 @@ use Yard\Brave\Components\Nav;
 use Yard\Brave\Components\PatternContent;
 use Yard\Brave\Components\ReadSpeaker;
 use Yard\Brave\Components\SocialIcon;
+use Yard\Brave\Components\Tooltip;
 use Yard\Hook\Registrar;
 
 class ComponentsServiceProvider extends PackageServiceProvider
@@ -26,7 +27,20 @@ class ComponentsServiceProvider extends PackageServiceProvider
 			->name('components')
 			->hasConfigFile()
 			->hasViews('brave')
-			->hasViewComponents('brave', Accordion::class, BackButton::class, Breadcrumb::class, Dialog::class, FeedbackForm::class,  ImgFocalPoint::class, Nav::class, PatternContent::class, ReadSpeaker::class, SocialIcon::class);
+			->hasViewComponents(
+				'brave',
+				Accordion::class,
+				BackButton::class,
+				Breadcrumb::class,
+				Dialog::class,
+				FeedbackForm::class,
+				ImgFocalPoint::class,
+				Nav::class,
+				PatternContent::class,
+				ReadSpeaker::class,
+				SocialIcon::class,
+				Tooltip::class
+			);
 	}
 
 	public function packageBooted(): void


### PR DESCRIPTION
Samen met javascript in brave-frontend-kit https://github.com/yardinternet/brave-frontend-kit/pull/47.

Een voorbeeld hoe ik het nu heb toegepast:
```
@foreach ($facets as $facet)
	@php
		$explanation = $getFacetExplanation($facet['name']);
		$tooltipId = $prefix . '-facet-explanation-tooltip-' . $facet['name'];
		$tooltipTriggerId = $prefix . '-facet-explanation-tooltip-button-' . $facet['name'];
	@endphp
	<div class="{{ $class }}">
		<fieldset>
			<legend class="mb-3">
				<h3 class="text-h5 {{ $headingClass }} mb-0">
					{{ $facet['label'] }}
					@if ($explanation)
						<x-brave::tooltip.trigger :id="$tooltipTriggerId" :ariaDescribedby="$tooltipId" :aria-label="'Toelichting bij ' . $facet['label']">
							<i class="fa-light fa-circle-info" aria-hidden="true"></i>
						</x-brave::tooltip.trigger>
					@endif
				</h3>
			</legend>
			@if ($explanation)
				<x-brave::tooltip :id="$tooltipId"
					class="z-999 rounded-theme visible absolute hidden w-max max-w-[min(400px,calc(100%-2rem))] bg-white px-6 py-3 shadow-2xl"
					arrowClass="absolute size-4 rotate-45 bg-white">
					{{ $explanation }}
				</x-brave::tooltip>
			@endif
			{!! facetwp_display('facet', $facet['name']) !!}
		</fieldset>
	</div>
@endforeach
```