### PR TITLE
fix: handle null Tolkie token configuration

### DIFF
--- a/src/ComponentsServiceProvider.php
+++ b/src/ComponentsServiceProvider.php
@@ -57,7 +57,8 @@ class ComponentsServiceProvider extends PackageServiceProvider
 			$hooks[] = Hooks\ReadSpeaker::class;
 		}
 
-		if ('' !== config('components.tolkie.token', '')) {
+		// config() may return null even though an empty string is provided as the default.
+		if ('' !== (string) config('components.tolkie.token', '')) {
 			$hooks[] = Hooks\Tolkie::class;
 		}
 


### PR DESCRIPTION
The config value is cast to a string before checking whether it is empty. This prevents the feature from being incorrectly enabled when the configuration resolves to null, since null is not an empty string.