### PR TITLE
fix: add token check to tolkie component

### DIFF
--- a/src/Components/Tolkie.php
+++ b/src/Components/Tolkie.php
@@ -10,8 +10,12 @@ use Illuminate\View\View;
 
 class Tolkie extends Component
 {
-	public function render(): Factory|View
+	public function render(): Factory|View|string
 	{
+		if ('' === (string) config('components.tolkie.token', '')) {
+			return '';
+		}
+
 		return view('brave::components.tolkie');
 	}
 }


### PR DESCRIPTION
Bij participatie ben ik `<x-brave-tolkie />` aan het toevoegen in de templates maar niet alle klanten hebben tolkie dus dan komt die lege div er wel te staan, niet zo netjes natuurlijk.