### PR TITLE
fix: make readspeaker customer id config work with default null value

### DIFF
--- a/src/Components/ReadSpeaker.php
+++ b/src/Components/ReadSpeaker.php
@@ -17,9 +17,9 @@ class ReadSpeaker extends Component
 
 	public function __construct()
 	{
-		$this->customerId = (int) config('components.read_speaker.customer_id', config('components.readSpeaker.customerId', 0));
+		$this->customerId = (int) (config('components.read_speaker.customer_id') ?? config('components.readSpeaker.customerId', 0));
 		// use old config names as fallback for backwards-compatibility
-		$this->readId = config('components.read_speaker.read_id', config('components.readSpeaker.readId', 'main'));
+		$this->readId = config('components.read_speaker.read_id') ?? config('components.readSpeaker.readId', 'main');
 
 		if (0 !== $this->customerId) {
 			$this->src = add_query_arg(

--- a/src/ComponentsServiceProvider.php
+++ b/src/ComponentsServiceProvider.php
@@ -53,7 +53,7 @@ class ComponentsServiceProvider extends PackageServiceProvider
 			$hooks[] = Hooks\PatternContent::class;
 		}
 
-		if (0 !== (int) config('components.read_speaker.customer_id', config('components.readSpeaker.customerId', 0))) {
+		if (0 !== (int) (config('components.read_speaker.customer_id') ?? config('components.readSpeaker.customerId', 0))) {
 			$hooks[] = Hooks\ReadSpeaker::class;
 		}
 

--- a/src/Hooks/ReadSpeaker.php
+++ b/src/Hooks/ReadSpeaker.php
@@ -18,7 +18,7 @@ class ReadSpeaker
 	public function __construct()
 	{
 		// use old config names as fallback for backwards-compatibility
-		$this->customerId = (int) config('components.read_speaker.customer_id', config('components.readSpeaker.customerId', 0));
+		$this->customerId = (int) (config('components.read_speaker.customer_id') ?? config('components.readSpeaker.customerId', 0));
 		$this->disable = config('components.read_speaker.disable', config('components.readSpeaker.disable', ''));
 		$this->automaticallyAddToH1 = (bool) config('components.read_speaker.automatically_add_to_h1', config('components.readSpeaker.automaticallyAddToH1', true));
 	}


### PR DESCRIPTION
In oude config die nog gebruik maken van camelCase properties gaat het ophalen van het readspeaker id niet goed omdat de default value van null voorkomt dat de fallback van de config functie wordt gebruikt.