### PR TITLE
feat: positie readspeaker-knop bij H1 instelbaar

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,21 @@ Configure the admin behavior of each pattern in the `components.php` config file
 
 ### Read Speaker
 
-Adds a ReadSpeaker button on specific places with the component and automatically adds it to the content of H1 blocks in the post content. Make sure to configure the `readSpeaker` settings in the `components.php` config file to set your customer ID and other options.
+Adds a ReadSpeaker button on specific places with the component and automatically adds it to the content of H1 blocks in the post content. Make sure to configure the `read_speaker` settings in the `components.php` config file to set your customer ID and other options.
 
 Usage:
 
 ```blade
 <x-brave-read-speaker />
+```
+
+Set `h1_position` to `before` to render the button above the heading instead of below it. It defaults to `after`.
+
+```php
+'read_speaker' => [
+    'automatically_add_to_h1' => true,
+    'h1_position' => 'before',
+],
 ```
 
 ### Tolkie

--- a/config/components.php
+++ b/config/components.php
@@ -36,7 +36,7 @@ return [
 		'read_id' => 'main',
 		'disable' => '',
 		'automatically_add_to_h1' => true,
-		'h1_position' => 'before', // 'before' or 'after'
+		'h1_position' => 'after', // 'before' or 'after'
 	],
 	'tolkie' => [
 		'token' => null,

--- a/config/components.php
+++ b/config/components.php
@@ -36,6 +36,7 @@ return [
 		'read_id' => 'main',
 		'disable' => '',
 		'automatically_add_to_h1' => true,
+		'h1_position' => 'before', // 'before' or 'after'
 	],
 	'tolkie' => [
 		'token' => null,

--- a/src/Hooks/ReadSpeaker.php
+++ b/src/Hooks/ReadSpeaker.php
@@ -11,9 +11,13 @@ use Yard\Hook\Filter;
 
 class ReadSpeaker
 {
+	public const POSITION_BEFORE = 'before';
+	public const POSITION_AFTER = 'after';
+
 	private int $customerId;
 	private string $disable;
 	private bool $automaticallyAddToH1;
+	private string $h1Position;
 
 	public function __construct()
 	{
@@ -21,6 +25,9 @@ class ReadSpeaker
 		$this->customerId = (int) (config('components.read_speaker.customer_id') ?? config('components.readSpeaker.customerId', 0));
 		$this->disable = config('components.read_speaker.disable', config('components.readSpeaker.disable', ''));
 		$this->automaticallyAddToH1 = (bool) config('components.read_speaker.automatically_add_to_h1', config('components.readSpeaker.automaticallyAddToH1', true));
+		$this->h1Position = self::POSITION_BEFORE === config('components.read_speaker.h1_position')
+			? self::POSITION_BEFORE
+			: self::POSITION_AFTER;
 	}
 
 	/**
@@ -46,7 +53,8 @@ class ReadSpeaker
 	}
 
 	/**
-	 * Add the ReadSpeaker button partial to H1's
+	 * Add the ReadSpeaker button partial to H1's, either before or after the
+	 * heading depending on the h1_position config value.
 	 */
 	#[Filter('render_block_core/heading')]
 	#[Filter('render_block_core/post-title')]
@@ -57,7 +65,11 @@ class ReadSpeaker
 		}
 
 		if (isset($block['attrs']['level']) && (int) $block['attrs']['level'] === 1) {
-			return $blockContent . Blade::renderComponent(new ReadSpeakerComponent());
+			$button = Blade::renderComponent(new ReadSpeakerComponent());
+
+			return self::POSITION_BEFORE === $this->h1Position
+				? $button . $blockContent
+				: $blockContent . $button;
 		}
 
 		return $blockContent;


### PR DESCRIPTION
`automatically_add_to_h1` zet de knop altijd ná de H1. Dat is niet instelbaar en er zit geen filter in de hook, dus een site die de knop erboven wil moet de hook uitzetten en de plaatsing zelf opnieuw bouwen. Dat hebben we nu op Geertruidenberg gedaan.

Deze PR maakt de positie instelbaar met `h1_position`: `before` of `after`.

```php
'read_speaker' => [
    'automatically_add_to_h1' => true,
    'h1_position' => 'before',
],
```

Default blijft `after`, dus puur opt-in. Bestaande sites merken er niets van, ook niet als ze de key niet zetten.

## Getest

Package lokaal in de vendor van Geertruidenberg gezet en op een pagina met een H1-block gecontroleerd:

- `before` → knop boven de H1, één knop
- `after` → knop onder de H1, één knop
- key weggelaten → knop onder de H1

phpstan schoon, php-cs-fixer schoon (0 van 24 files). Er staan geen tests in deze package, dus daar valt niets te draaien.

## Nog te bespreken

`Tolkie` heeft precies dezelfde hardcoded plaatsing na de H1. Kan dezelfde optie krijgen als jullie dat willen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
